### PR TITLE
Fix RF module key

### DIFF
--- a/MX3_CAN/message_parser.py
+++ b/MX3_CAN/message_parser.py
@@ -267,7 +267,7 @@ def parse_rf_module_status(
         )
 
         # Get the wireless AVR error code status
-        parsed_status["Wireless_Avr_Error_CodeS_tatus"] = GLOBAL_ZONE_STATUS.get(
+        parsed_status["Wireless_Avr_Error_Code_Status"] = GLOBAL_ZONE_STATUS.get(
             safe_get(data_bytes, 3), "Unknown"
         )
 


### PR DESCRIPTION
## Summary
- correct `parse_rf_module_status` dictionary key

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6865289743b883288bb18324c1b96179